### PR TITLE
Add `ipython_genutils` to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ipython_genutils
 nbconvert==5.6.1
 beautifulsoup4
 pyyaml


### PR DESCRIPTION
Fixes the following error:
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/44668836/158064324-3084777e-ba7d-4e2a-b201-74ba62ec0e34.png">
